### PR TITLE
fix: Fix env name typo in code

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -54,7 +54,7 @@ func (p *hookdeckProvider) Schema(ctx context.Context, req provider.SchemaReques
 			"api_key": schema.StringAttribute{
 				Optional:            true,
 				Sensitive:           true,
-				MarkdownDescription: fmt.Sprintf("Hookdeck API Key. Alternatively, can be configured using the `%s` environment variable.", apiBaseEnvVarKey),
+				MarkdownDescription: fmt.Sprintf("Hookdeck API Key. Alternatively, can be configured using the `%s` environment variable.", apiKeyEnvVarKey),
 			},
 		},
 	}


### PR DESCRIPTION
Following up on #24 here. The `docs` folder is autogenerated so it's typically not recommended to update it manually. This PR will fix it from the code side so that the next time we generate documentation this typo won't happen again.