### PR TITLE
feat: Improve filter validation to show error on misconfiguration

### DIFF
--- a/internal/provider/connection/schema.go
+++ b/internal/provider/connection/schema.go
@@ -31,6 +31,9 @@ func (r *connectionResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Optional: true,
 			},
 		},
+		Validators: []validator.Object{
+			validators.ExactlyOneChild(),
+		},
 	}
 
 	resp.Schema = schema.Schema{
@@ -110,6 +113,9 @@ func (r *connectionResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								"headers": filterRulePropertySchema,
 								"path":    filterRulePropertySchema,
 								"query":   filterRulePropertySchema,
+							},
+							Validators: []validator.Object{
+								validators.AtLeastOneChild(),
 							},
 						},
 						"retry_rule": schema.SingleNestedAttribute{

--- a/internal/validators/AtLeastOneChild.go
+++ b/internal/validators/AtLeastOneChild.go
@@ -7,13 +7,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
-var _ validator.Object = exactlyOneChild{}
+var _ validator.Object = atLeastOneChild{}
 
-// exactlyOneChild validates if the provided object has exactly one child attribute
-type exactlyOneChild struct {
+// atLeastOneChild validates if the provided object has at least one child attribute
+type atLeastOneChild struct {
 }
 
-func (validator exactlyOneChild) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+func (validator atLeastOneChild) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
 	// Only validate the attribute configuration value if it is known.
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
@@ -27,7 +27,7 @@ func (validator exactlyOneChild) ValidateObject(ctx context.Context, req validat
 		defined[key] = true
 		count++
 	}
-	if count != 1 {
+	if count < 1 {
 		resp.Diagnostics.Append(validatordiag.InvalidAttributeTypeDiagnostic(
 			req.Path,
 			validator.MarkdownDescription(ctx),
@@ -36,17 +36,17 @@ func (validator exactlyOneChild) ValidateObject(ctx context.Context, req validat
 	}
 }
 
-func (validator exactlyOneChild) Description(ctx context.Context) string {
-	return "value must have exactly one child attribute defined"
+func (validator atLeastOneChild) Description(ctx context.Context) string {
+	return "value must have at least one child attribute defined"
 }
 
-func (validator exactlyOneChild) MarkdownDescription(ctx context.Context) string {
+func (validator atLeastOneChild) MarkdownDescription(ctx context.Context) string {
 	return validator.Description(ctx)
 }
 
-// ExactlyOneChild returns an AttributeValidator which ensures that any configured
-// attribute object has only one child attribute.
+// AtLeastOneChild returns an AttributeValidator which ensures that any configured
+// attribute object has at least one child attribute.
 // Null (unconfigured) and unknown values are skipped.
-func ExactlyOneChild() validator.Object {
-	return exactlyOneChild{}
+func AtLeastOneChild() validator.Object {
+	return atLeastOneChild{}
 }

--- a/internal/validators/AtLeastOneChild.go
+++ b/internal/validators/AtLeastOneChild.go
@@ -9,7 +9,7 @@ import (
 
 var _ validator.Object = atLeastOneChild{}
 
-// atLeastOneChild validates if the provided object has at least one child attribute
+// atLeastOneChild validates if the provided object has at least one child attribute.
 type atLeastOneChild struct {
 }
 

--- a/internal/validators/ExactlyOneChild.go
+++ b/internal/validators/ExactlyOneChild.go
@@ -9,7 +9,7 @@ import (
 
 var _ validator.Object = exactlyOneChild{}
 
-// exactlyOneChild validates if the provided object has exactly one child attribute
+// exactlyOneChild validates if the provided object has exactly one child attribute.
 type exactlyOneChild struct {
 }
 


### PR DESCRIPTION
Improving the filter validation so that if users have a wrong TF resource configuration we'll throw an error. For example:

```tf
resource "hookdeck_connection" "connection_example" {
  source_id      = hookdeck_source.example.id
  destination_id = hookdeck_destination.destination_example.id
  name           = "my-connection"
  rules = [
    {
      filter_rule = {
        body = {
          hello = "world"
        }
      }
    }
  ]
}
```

will result in this error

```
│ Error: Invalid Attribute Type
│
│   with hookdeck_connection.connection_example,
│   on main.tf line 52, in resource "hookdeck_connection" "connection_example":
│   52: resource "hookdeck_connection" "connection_example" {
│
│ Attribute rules[0].filter_rule.body value must have exactly one child attribute defined, got:
│ {"boolean":<null>,"json":<null>,"number":<null>,"string":<null>}
```