### PR TITLE
fix: Count unknown value as present during attribute validation

### DIFF
--- a/internal/validators/AtLeastOneChild.go
+++ b/internal/validators/AtLeastOneChild.go
@@ -21,7 +21,7 @@ func (validator atLeastOneChild) ValidateObject(ctx context.Context, req validat
 	defined := make(map[string]bool)
 	count := 0
 	for key, attr := range req.ConfigValue.Attributes() {
-		if attr.IsUnknown() || attr.IsNull() {
+		if attr.IsNull() {
 			continue
 		}
 		defined[key] = true

--- a/internal/validators/ExactlyOneChild.go
+++ b/internal/validators/ExactlyOneChild.go
@@ -21,7 +21,7 @@ func (validator exactlyOneChild) ValidateObject(ctx context.Context, req validat
 	defined := make(map[string]bool)
 	count := 0
 	for key, attr := range req.ConfigValue.Attributes() {
-		if attr.IsUnknown() || attr.IsNull() {
+		if attr.IsNull() {
 			continue
 		}
 		defined[key] = true


### PR DESCRIPTION
We had previously considered an attribute with an unknown value (for example, yet to be evaluated, such as in the case of a variable being passed) as not counting towards the attribute count during validation. This change updates the validation logic to increment the count if the attribute value is unknown.