### PR TITLE
chore: Upgrade Hookdeck Go SDK to v0.3.0 to fix source verification JSON issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v1.8.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
-	github.com/hookdeck/hookdeck-go-sdk v0.2.0
+	github.com/hookdeck/hookdeck-go-sdk v0.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
-github.com/hookdeck/hookdeck-go-sdk v0.2.0 h1:IDY5dNiL4vKqyBAPXKa5CpKzl3kmHfObHnDGjJMvQUM=
-github.com/hookdeck/hookdeck-go-sdk v0.2.0/go.mod h1:kfFn3/WEGcxuPkaaf8lAq9L+3nYg45GwGy4utH/Tnmg=
+github.com/hookdeck/hookdeck-go-sdk v0.3.0 h1:LvSF5d9Yk62HIQOvy/tMXqbDT1N91T+kdIzKUPmzVdw=
+github.com/hookdeck/hookdeck-go-sdk v0.3.0/go.mod h1:kfFn3/WEGcxuPkaaf8lAq9L+3nYg45GwGy4utH/Tnmg=
 github.com/huandu/xstrings v1.3.3 h1:/Gcsuc1x8JVbJ9/rlye4xZnVAbEkGauT8lbebqcQws4=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/internal/provider/connection/sdk.go
+++ b/internal/provider/connection/sdk.go
@@ -58,7 +58,7 @@ func (m *connectionResourceModel) getRules() *[]*hookdeck.Rule {
 			delayRule := hookdeck.DelayRule{
 				Delay: int(ruleItem.DelayRule.Delay.ValueInt64()),
 			}
-			rules = append(rules, hookdeck.NewRuleFromDelayRule(&delayRule))
+			rules = append(rules, hookdeck.NewRuleFromDelay(&delayRule))
 		}
 		if ruleItem.FilterRule != nil {
 			filterRule := hookdeck.FilterRule{
@@ -67,7 +67,7 @@ func (m *connectionResourceModel) getRules() *[]*hookdeck.Rule {
 				Path:    transformFilterRuleProperty(ruleItem.FilterRule.Path),
 				Query:   transformFilterRuleProperty(ruleItem.FilterRule.Query),
 			}
-			rules = append(rules, hookdeck.NewRuleFromFilterRule(&filterRule))
+			rules = append(rules, hookdeck.NewRuleFromFilter(&filterRule))
 		}
 		if ruleItem.RetryRule != nil {
 			count := new(int)
@@ -87,13 +87,13 @@ func (m *connectionResourceModel) getRules() *[]*hookdeck.Rule {
 				Interval: interval,
 				Count:    count,
 			}
-			rules = append(rules, hookdeck.NewRuleFromRetryRule(&retryRule))
+			rules = append(rules, hookdeck.NewRuleFromRetry(&retryRule))
 		}
 		if ruleItem.TransformRule != nil {
-			transformRule := hookdeck.NewTransformRuleFromTransformReference(&hookdeck.TransformReference{
-				TransformationId: ruleItem.TransformRule.TransformationID.ValueString(),
-			})
-			rules = append(rules, hookdeck.NewRuleFromTransformRule(transformRule))
+			transformRule := hookdeck.TransformRule{
+				TransformationId: ruleItem.TransformRule.TransformationID.ValueStringPointer(),
+			}
+			rules = append(rules, hookdeck.NewRuleFromTransform(&transformRule))
 		}
 	}
 

--- a/internal/provider/sourceverification/verification_adyen.go
+++ b/internal/provider/sourceverification/verification_adyen.go
@@ -23,8 +23,7 @@ type adyenSourceVerification struct {
 }
 
 func (m *adyenSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationAdyen(&hookdeck.VerificationAdyen{
-		Type: hookdeck.VerificationAdyenTypeAdyen,
+	return hookdeck.NewVerificationConfigFromAdyen(&hookdeck.VerificationAdyen{
 		Configs: &hookdeck.VerificationAdyenConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_akeneo.go
+++ b/internal/provider/sourceverification/verification_akeneo.go
@@ -23,8 +23,7 @@ type akeneoSourceVerification struct {
 }
 
 func (m *akeneoSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationAkeneo(&hookdeck.VerificationAkeneo{
-		Type: hookdeck.VerificationAkeneoTypeAkeneo,
+	return hookdeck.NewVerificationConfigFromAkeneo(&hookdeck.VerificationAkeneo{
 		Configs: &hookdeck.VerificationAkeneoConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_apikey.go
+++ b/internal/provider/sourceverification/verification_apikey.go
@@ -27,8 +27,7 @@ type apiKeySourceVerification struct {
 }
 
 func (m *apiKeySourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationApiKey(&hookdeck.VerificationApiKey{
-		Type: hookdeck.VerificationApiKeyTypeApiKey,
+	return hookdeck.NewVerificationConfigFromApiKey(&hookdeck.VerificationApiKey{
 		Configs: &hookdeck.VerificationApiKeyConfigs{
 			ApiKey:    m.APIKey.ValueString(),
 			HeaderKey: m.HeaderKey.ValueString(),

--- a/internal/provider/sourceverification/verification_awssns.go
+++ b/internal/provider/sourceverification/verification_awssns.go
@@ -16,8 +16,7 @@ type awsSNSSourceVerification struct {
 }
 
 func (m *awsSNSSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationAwssns(&hookdeck.VerificationAwssns{
-		Type:    hookdeck.VerificationAwssnsTypeAwsSns,
+	return hookdeck.NewVerificationConfigFromAwsSns(&hookdeck.VerificationAwssns{
 		Configs: &hookdeck.VerificationAwssnsConfigs{},
 	})
 }

--- a/internal/provider/sourceverification/verification_basicauth.go
+++ b/internal/provider/sourceverification/verification_basicauth.go
@@ -27,8 +27,7 @@ type basicAuthSourceVerification struct {
 }
 
 func (m *basicAuthSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationBasicAuth(&hookdeck.VerificationBasicAuth{
-		Type: hookdeck.VerificationBasicAuthTypeBasicAuth,
+	return hookdeck.NewVerificationConfigFromBasicAuth(&hookdeck.VerificationBasicAuth{
 		Configs: &hookdeck.VerificationBasicAuthConfigs{
 			Username: m.Username.ValueString(),
 			Password: m.Password.ValueString(),

--- a/internal/provider/sourceverification/verification_bondsmith.go
+++ b/internal/provider/sourceverification/verification_bondsmith.go
@@ -23,8 +23,7 @@ type bondsmithSourceVerification struct {
 }
 
 func (m *bondsmithSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationBondsmith(&hookdeck.VerificationBondsmith{
-		Type: hookdeck.VerificationBondsmithTypeBondsmith,
+	return hookdeck.NewVerificationConfigFromBondsmith(&hookdeck.VerificationBondsmith{
 		Configs: &hookdeck.VerificationBondsmithConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_cloudsignal.go
+++ b/internal/provider/sourceverification/verification_cloudsignal.go
@@ -23,8 +23,7 @@ type cloudsignalSourceVerification struct {
 }
 
 func (m *cloudsignalSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationCloudSignal(&hookdeck.VerificationCloudSignal{
-		Type: hookdeck.VerificationCloudSignalTypeCloudsignal,
+	return hookdeck.NewVerificationConfigFromCloudsignal(&hookdeck.VerificationCloudSignal{
 		Configs: &hookdeck.VerificationCloudSignalConfigs{
 			ApiKey: m.APIKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_commercelayer.go
+++ b/internal/provider/sourceverification/verification_commercelayer.go
@@ -23,8 +23,7 @@ type commercelayerSourceVerification struct {
 }
 
 func (m *commercelayerSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationCommercelayer(&hookdeck.VerificationCommercelayer{
-		Type: hookdeck.VerificationCommercelayerTypeCommercelayer,
+	return hookdeck.NewVerificationConfigFromCommercelayer(&hookdeck.VerificationCommercelayer{
 		Configs: &hookdeck.VerificationCommercelayerConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_courier.go
+++ b/internal/provider/sourceverification/verification_courier.go
@@ -23,8 +23,7 @@ type courierSourceVerification struct {
 }
 
 func (m *courierSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationCourier(&hookdeck.VerificationCourier{
-		Type: hookdeck.VerificationCourierTypeCourier,
+	return hookdeck.NewVerificationConfigFromCourier(&hookdeck.VerificationCourier{
 		Configs: &hookdeck.VerificationCourierConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_ebay.go
+++ b/internal/provider/sourceverification/verification_ebay.go
@@ -43,8 +43,7 @@ type ebaySourceVerification struct {
 }
 
 func (m *ebaySourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationEbay(&hookdeck.VerificationEbay{
-		Type: hookdeck.VerificationEbayTypeEbay,
+	return hookdeck.NewVerificationConfigFromEbay(&hookdeck.VerificationEbay{
 		Configs: &hookdeck.VerificationEbayConfigs{
 			ClientId:          m.ClientId.ValueString(),
 			ClientSecret:      m.ClientSecret.ValueString(),

--- a/internal/provider/sourceverification/verification_enode.go
+++ b/internal/provider/sourceverification/verification_enode.go
@@ -23,8 +23,7 @@ type enodeSourceVerification struct {
 }
 
 func (m *enodeSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationEnode(&hookdeck.VerificationEnode{
-		Type: hookdeck.VerificationEnodeTypeEnode,
+	return hookdeck.NewVerificationConfigFromEnode(&hookdeck.VerificationEnode{
 		Configs: &hookdeck.VerificationEnodeConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_favro.go
+++ b/internal/provider/sourceverification/verification_favro.go
@@ -23,8 +23,7 @@ type favroSourceVerification struct {
 }
 
 func (m *favroSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationFavro(&hookdeck.VerificationFavro{
-		Type: hookdeck.VerificationFavroTypeFavro,
+	return hookdeck.NewVerificationConfigFromFavro(&hookdeck.VerificationFavro{
 		Configs: &hookdeck.VerificationFavroConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_fiserv.go
+++ b/internal/provider/sourceverification/verification_fiserv.go
@@ -23,8 +23,7 @@ type fiservSourceVerification struct {
 }
 
 func (m *fiservSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationFiserv(&hookdeck.VerificationFiserv{
-		Type: hookdeck.VerificationFiservTypeFiserv,
+	return hookdeck.NewVerificationConfigFromFiserv(&hookdeck.VerificationFiserv{
 		Configs: &hookdeck.VerificationFiservConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_frontapp.go
+++ b/internal/provider/sourceverification/verification_frontapp.go
@@ -23,8 +23,7 @@ type frontAppSourceVerification struct {
 }
 
 func (m *frontAppSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationFrontApp(&hookdeck.VerificationFrontApp{
-		Type: hookdeck.VerificationFrontAppTypeFrontapp,
+	return hookdeck.NewVerificationConfigFromFrontapp(&hookdeck.VerificationFrontApp{
 		Configs: &hookdeck.VerificationFrontAppConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_github.go
+++ b/internal/provider/sourceverification/verification_github.go
@@ -23,8 +23,7 @@ type githubSourceVerification struct {
 }
 
 func (m *githubSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationGitHub(&hookdeck.VerificationGitHub{
-		Type: hookdeck.VerificationGitHubTypeGithub,
+	return hookdeck.NewVerificationConfigFromGithub(&hookdeck.VerificationGitHub{
 		Configs: &hookdeck.VerificationGitHubConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_gitlab.go
+++ b/internal/provider/sourceverification/verification_gitlab.go
@@ -23,8 +23,7 @@ type gitlabSourceVerification struct {
 }
 
 func (m *gitlabSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationGitLab(&hookdeck.VerificationGitLab{
-		Type: hookdeck.VerificationGitLabTypeGitlab,
+	return hookdeck.NewVerificationConfigFromGitlab(&hookdeck.VerificationGitLab{
 		Configs: &hookdeck.VerificationGitLabConfigs{
 			ApiKey: m.APIKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_hmac.go
+++ b/internal/provider/sourceverification/verification_hmac.go
@@ -39,8 +39,7 @@ type hmacSourceVerification struct {
 func (m *hmacSourceVerification) toPayload() *hookdeck.VerificationConfig {
 	algorithm, _ := hookdeck.NewHmacAlgorithmsFromString(m.Algorithm.ValueString())
 	encoding, _ := hookdeck.NewVerificationHmacConfigsEncodingFromString(m.Encoding.ValueString())
-	return hookdeck.NewVerificationConfigFromVerificationHmac(&hookdeck.VerificationHmac{
-		Type: hookdeck.VerificationHmacTypeHmac,
+	return hookdeck.NewVerificationConfigFromHmac(&hookdeck.VerificationHmac{
 		Configs: &hookdeck.VerificationHmacConfigs{
 			Algorithm:        algorithm,
 			Encoding:         encoding,

--- a/internal/provider/sourceverification/verification_linear.go
+++ b/internal/provider/sourceverification/verification_linear.go
@@ -23,8 +23,7 @@ type linearSourceVerification struct {
 }
 
 func (m *linearSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationLinear(&hookdeck.VerificationLinear{
-		Type: hookdeck.VerificationLinearTypeLinear,
+	return hookdeck.NewVerificationConfigFromLinear(&hookdeck.VerificationLinear{
 		Configs: &hookdeck.VerificationLinearConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_mailgun.go
+++ b/internal/provider/sourceverification/verification_mailgun.go
@@ -23,8 +23,7 @@ type mailgunSourceVerification struct {
 }
 
 func (m *mailgunSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationMailgun(&hookdeck.VerificationMailgun{
-		Type: hookdeck.VerificationMailgunTypeMailgun,
+	return hookdeck.NewVerificationConfigFromMailgun(&hookdeck.VerificationMailgun{
 		Configs: &hookdeck.VerificationMailgunConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_nmi.go
+++ b/internal/provider/sourceverification/verification_nmi.go
@@ -23,8 +23,7 @@ type nmiSourceVerification struct {
 }
 
 func (m *nmiSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationNmiPaymentGateway(&hookdeck.VerificationNmiPaymentGateway{
-		Type: hookdeck.VerificationNmiPaymentGatewayTypeNmi,
+	return hookdeck.NewVerificationConfigFromNmi(&hookdeck.VerificationNmiPaymentGateway{
 		Configs: &hookdeck.VerificationNmiPaymentGatewayConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_orb.go
+++ b/internal/provider/sourceverification/verification_orb.go
@@ -23,8 +23,7 @@ type orbSourceVerification struct {
 }
 
 func (m *orbSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationOrb(&hookdeck.VerificationOrb{
-		Type: hookdeck.VerificationOrbTypeOrb,
+	return hookdeck.NewVerificationConfigFromOrb(&hookdeck.VerificationOrb{
 		Configs: &hookdeck.VerificationOrbConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_oura.go
+++ b/internal/provider/sourceverification/verification_oura.go
@@ -23,8 +23,7 @@ type ouraSourceVerification struct {
 }
 
 func (m *ouraSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationOura(&hookdeck.VerificationOura{
-		Type: hookdeck.VerificationOuraTypeOura,
+	return hookdeck.NewVerificationConfigFromOura(&hookdeck.VerificationOura{
 		Configs: &hookdeck.VerificationOuraConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_persona.go
+++ b/internal/provider/sourceverification/verification_persona.go
@@ -23,8 +23,7 @@ type personaSourceVerification struct {
 }
 
 func (m *personaSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationPersona(&hookdeck.VerificationPersona{
-		Type: hookdeck.VerificationPersonaTypePersona,
+	return hookdeck.NewVerificationConfigFromPersona(&hookdeck.VerificationPersona{
 		Configs: &hookdeck.VerificationPersonaConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_pipedrive.go
+++ b/internal/provider/sourceverification/verification_pipedrive.go
@@ -27,8 +27,7 @@ type pipedriveSourceVerification struct {
 }
 
 func (m *pipedriveSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationPipedrive(&hookdeck.VerificationPipedrive{
-		Type: hookdeck.VerificationPipedriveTypePipedrive,
+	return hookdeck.NewVerificationConfigFromPipedrive(&hookdeck.VerificationPipedrive{
 		Configs: &hookdeck.VerificationPipedriveConfigs{
 			Username: m.Username.ValueString(),
 			Password: m.Password.ValueString(),

--- a/internal/provider/sourceverification/verification_postmark.go
+++ b/internal/provider/sourceverification/verification_postmark.go
@@ -24,8 +24,7 @@ type postmarkSourceVerification struct {
 }
 
 func (m *postmarkSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationPostmark(&hookdeck.VerificationPostmark{
-		Type: hookdeck.VerificationPostmarkTypePostmark,
+	return hookdeck.NewVerificationConfigFromPostmark(&hookdeck.VerificationPostmark{
 		Configs: &hookdeck.VerificationPostmarkConfigs{
 			Username: m.Username.ValueString(),
 			Password: m.Password.ValueString(),

--- a/internal/provider/sourceverification/verification_propertyfinder.go
+++ b/internal/provider/sourceverification/verification_propertyfinder.go
@@ -23,8 +23,7 @@ type propertyFinderSourceVerification struct {
 }
 
 func (m *propertyFinderSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationPropertyFinder(&hookdeck.VerificationPropertyFinder{
-		Type: "PROPERTY-FINDER",
+	return hookdeck.NewVerificationConfigFromPropertyFinder(&hookdeck.VerificationPropertyFinder{
 		Configs: &hookdeck.VerificationPropertyFinderConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_pylon.go
+++ b/internal/provider/sourceverification/verification_pylon.go
@@ -23,8 +23,7 @@ type pylonSourceVerification struct {
 }
 
 func (m *pylonSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationPylon(&hookdeck.VerificationPylon{
-		Type: hookdeck.VerificationPylonTypePylon,
+	return hookdeck.NewVerificationConfigFromPylon(&hookdeck.VerificationPylon{
 		Configs: &hookdeck.VerificationPylonConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_recharge.go
+++ b/internal/provider/sourceverification/verification_recharge.go
@@ -39,8 +39,7 @@ type rechargeSourceVerification struct {
 func (m *rechargeSourceVerification) toPayload() *hookdeck.VerificationConfig {
 	algorithm, _ := hookdeck.NewHmacAlgorithmsFromString(m.Algorithm.ValueString())
 	encoding, _ := hookdeck.NewVerificationRechargeConfigsEncodingFromString(m.Encoding.ValueString())
-	return hookdeck.NewVerificationConfigFromVerificationRecharge(&hookdeck.VerificationRecharge{
-		Type: hookdeck.VerificationRechargeTypeRecharge,
+	return hookdeck.NewVerificationConfigFromRecharge(&hookdeck.VerificationRecharge{
 		Configs: &hookdeck.VerificationRechargeConfigs{
 			Algorithm:        algorithm,
 			Encoding:         encoding,

--- a/internal/provider/sourceverification/verification_repay.go
+++ b/internal/provider/sourceverification/verification_repay.go
@@ -23,8 +23,7 @@ type repaySourceVerification struct {
 }
 
 func (m *repaySourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationRepay(&hookdeck.VerificationRepay{
-		Type: hookdeck.VerificationRepayTypeRepay,
+	return hookdeck.NewVerificationConfigFromRepay(&hookdeck.VerificationRepay{
 		Configs: &hookdeck.VerificationRepayConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_sanity.go
+++ b/internal/provider/sourceverification/verification_sanity.go
@@ -23,8 +23,7 @@ type sanitySourceVerification struct {
 }
 
 func (m *sanitySourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationSanity(&hookdeck.VerificationSanity{
-		Type: hookdeck.VerificationSanityTypeSanity,
+	return hookdeck.NewVerificationConfigFromSanity(&hookdeck.VerificationSanity{
 		Configs: &hookdeck.VerificationSanityConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_sendgrid.go
+++ b/internal/provider/sourceverification/verification_sendgrid.go
@@ -23,8 +23,7 @@ type sendgridSourceVerification struct {
 }
 
 func (m *sendgridSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationSendGrid(&hookdeck.VerificationSendGrid{
-		Type: hookdeck.VerificationSendGridTypeSendgrid,
+	return hookdeck.NewVerificationConfigFromSendgrid(&hookdeck.VerificationSendGrid{
 		Configs: &hookdeck.VerificationSendGridConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_shopify.go
+++ b/internal/provider/sourceverification/verification_shopify.go
@@ -23,8 +23,7 @@ type shopifySourceVerification struct {
 }
 
 func (m *shopifySourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationShopify(&hookdeck.VerificationShopify{
-		Type: hookdeck.VerificationShopifyTypeShopify,
+	return hookdeck.NewVerificationConfigFromShopify(&hookdeck.VerificationShopify{
 		Configs: &hookdeck.VerificationShopifyConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_shopline.go
+++ b/internal/provider/sourceverification/verification_shopline.go
@@ -23,8 +23,7 @@ type shoplineSourceVerification struct {
 }
 
 func (m *shoplineSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationShopline(&hookdeck.VerificationShopline{
-		Type: hookdeck.VerificationShoplineTypeShopline,
+	return hookdeck.NewVerificationConfigFromShopline(&hookdeck.VerificationShopline{
 		Configs: &hookdeck.VerificationShoplineConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_solidgate.go
+++ b/internal/provider/sourceverification/verification_solidgate.go
@@ -23,8 +23,7 @@ type solidgateSourceVerification struct {
 }
 
 func (m *solidgateSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationSolidGate(&hookdeck.VerificationSolidGate{
-		Type: hookdeck.VerificationSolidGateTypeSolidgate,
+	return hookdeck.NewVerificationConfigFromSolidgate(&hookdeck.VerificationSolidGate{
 		Configs: &hookdeck.VerificationSolidGateConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_square.go
+++ b/internal/provider/sourceverification/verification_square.go
@@ -23,8 +23,7 @@ type squareSourceVerification struct {
 }
 
 func (m *squareSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationSquare(&hookdeck.VerificationSquare{
-		Type: hookdeck.VerificationSquareTypeSquare,
+	return hookdeck.NewVerificationConfigFromSquare(&hookdeck.VerificationSquare{
 		Configs: &hookdeck.VerificationSquareConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_stripe.go
+++ b/internal/provider/sourceverification/verification_stripe.go
@@ -23,8 +23,7 @@ type stripeSourceVerification struct {
 }
 
 func (m *stripeSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationStripe(&hookdeck.VerificationStripe{
-		Type: hookdeck.VerificationStripeTypeStripe,
+	return hookdeck.NewVerificationConfigFromStripe(&hookdeck.VerificationStripe{
 		Configs: &hookdeck.VerificationStripeConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_svix.go
+++ b/internal/provider/sourceverification/verification_svix.go
@@ -23,8 +23,7 @@ type svixSourceVerification struct {
 }
 
 func (m *svixSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationSvix(&hookdeck.VerificationSvix{
-		Type: hookdeck.VerificationSvixTypeSvix,
+	return hookdeck.NewVerificationConfigFromSvix(&hookdeck.VerificationSvix{
 		Configs: &hookdeck.VerificationSvixConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_synctera.go
+++ b/internal/provider/sourceverification/verification_synctera.go
@@ -23,8 +23,7 @@ type syncteraSourceVerification struct {
 }
 
 func (m *syncteraSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationSynctera(&hookdeck.VerificationSynctera{
-		Type: hookdeck.VerificationSyncteraTypeSynctera,
+	return hookdeck.NewVerificationConfigFromSynctera(&hookdeck.VerificationSynctera{
 		Configs: &hookdeck.VerificationSyncteraConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_telnyx.go
+++ b/internal/provider/sourceverification/verification_telnyx.go
@@ -23,8 +23,7 @@ type telnyxSourceVerification struct {
 }
 
 func (m *telnyxSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationTelnyx(&hookdeck.VerificationTelnyx{
-		Type: hookdeck.VerificationTelnyxTypeTelnyx,
+	return hookdeck.NewVerificationConfigFromTelnyx(&hookdeck.VerificationTelnyx{
 		Configs: &hookdeck.VerificationTelnyxConfigs{
 			PublicKey: m.PublicKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_threedeye.go
+++ b/internal/provider/sourceverification/verification_threedeye.go
@@ -23,8 +23,7 @@ type threeDEyeSourceVerification struct {
 }
 
 func (m *threeDEyeSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerification3DEye(&hookdeck.Verification3DEye{
-		Type: hookdeck.Verification3DEyeTypeThreeDEye,
+	return hookdeck.NewVerificationConfigFromThreeDEye(&hookdeck.Verification3DEye{
 		Configs: &hookdeck.Verification3DEyeConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_tokenio.go
+++ b/internal/provider/sourceverification/verification_tokenio.go
@@ -23,8 +23,7 @@ type tokenIoSourceVerification struct {
 }
 
 func (m *tokenIoSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationTokenIo(&hookdeck.VerificationTokenIo{
-		Type: hookdeck.VerificationTokenIoTypeTokenio,
+	return hookdeck.NewVerificationConfigFromTokenio(&hookdeck.VerificationTokenIo{
 		Configs: &hookdeck.VerificationTokenIoConfigs{
 			PublicKey: m.PublicKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_trello.go
+++ b/internal/provider/sourceverification/verification_trello.go
@@ -23,8 +23,7 @@ type trelloSourceVerification struct {
 }
 
 func (m *trelloSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationTrello(&hookdeck.VerificationTrello{
-		Type: hookdeck.VerificationTrelloTypeTrello,
+	return hookdeck.NewVerificationConfigFromTrello(&hookdeck.VerificationTrello{
 		Configs: &hookdeck.VerificationTrelloConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_twitch.go
+++ b/internal/provider/sourceverification/verification_twitch.go
@@ -23,8 +23,7 @@ type twitchSourceVerification struct {
 }
 
 func (m *twitchSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationTwitch(&hookdeck.VerificationTwitch{
-		Type: hookdeck.VerificationTwitchTypeTwitch,
+	return hookdeck.NewVerificationConfigFromTwitch(&hookdeck.VerificationTwitch{
 		Configs: &hookdeck.VerificationTwitchConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_twitter.go
+++ b/internal/provider/sourceverification/verification_twitter.go
@@ -23,8 +23,7 @@ type twitterSourceVerification struct {
 }
 
 func (m *twitterSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationTwitter(&hookdeck.VerificationTwitter{
-		Type: hookdeck.VerificationTwitterTypeTwitter,
+	return hookdeck.NewVerificationConfigFromTwitter(&hookdeck.VerificationTwitter{
 		Configs: &hookdeck.VerificationTwitterConfigs{
 			ApiKey: m.APIKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_typeform.go
+++ b/internal/provider/sourceverification/verification_typeform.go
@@ -23,8 +23,7 @@ type typeformSourceVerification struct {
 }
 
 func (m *typeformSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationTypeform(&hookdeck.VerificationTypeform{
-		Type: hookdeck.VerificationTypeformTypeTypeform,
+	return hookdeck.NewVerificationConfigFromTypeform(&hookdeck.VerificationTypeform{
 		Configs: &hookdeck.VerificationTypeformConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_wix.go
+++ b/internal/provider/sourceverification/verification_wix.go
@@ -23,8 +23,7 @@ type wixSourceVerification struct {
 }
 
 func (m *wixSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationWix(&hookdeck.VerificationWix{
-		Type: hookdeck.VerificationWixTypeWix,
+	return hookdeck.NewVerificationConfigFromWix(&hookdeck.VerificationWix{
 		Configs: &hookdeck.VerificationWixConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_woocommerce.go
+++ b/internal/provider/sourceverification/verification_woocommerce.go
@@ -23,8 +23,7 @@ type woocommerceSourceVerification struct {
 }
 
 func (m *woocommerceSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationWooCommerce(&hookdeck.VerificationWooCommerce{
-		Type: hookdeck.VerificationWooCommerceTypeWoocommerce,
+	return hookdeck.NewVerificationConfigFromWoocommerce(&hookdeck.VerificationWooCommerce{
 		Configs: &hookdeck.VerificationWooCommerceConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_workos.go
+++ b/internal/provider/sourceverification/verification_workos.go
@@ -23,8 +23,7 @@ type workOSSourceVerification struct {
 }
 
 func (m *workOSSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationWorkOs(&hookdeck.VerificationWorkOs{
-		Type: hookdeck.VerificationWorkOsTypeWorkos,
+	return hookdeck.NewVerificationConfigFromWorkos(&hookdeck.VerificationWorkOs{
 		Configs: &hookdeck.VerificationWorkOsConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_xero.go
+++ b/internal/provider/sourceverification/verification_xero.go
@@ -23,8 +23,7 @@ type xeroSourceVerification struct {
 }
 
 func (m *xeroSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationXero(&hookdeck.VerificationXero{
-		Type: hookdeck.VerificationXeroTypeXero,
+	return hookdeck.NewVerificationConfigFromXero(&hookdeck.VerificationXero{
 		Configs: &hookdeck.VerificationXeroConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},

--- a/internal/provider/sourceverification/verification_zoom.go
+++ b/internal/provider/sourceverification/verification_zoom.go
@@ -23,8 +23,7 @@ type zoomSourceVerification struct {
 }
 
 func (m *zoomSourceVerification) toPayload() *hookdeck.VerificationConfig {
-	return hookdeck.NewVerificationConfigFromVerificationZoom(&hookdeck.VerificationZoom{
-		Type: hookdeck.VerificationZoomTypeZoom,
+	return hookdeck.NewVerificationConfigFromZoom(&hookdeck.VerificationZoom{
 		Configs: &hookdeck.VerificationZoomConfigs{
 			WebhookSecretKey: m.WebhookSecretKey.ValueString(),
 		},


### PR DESCRIPTION
Tested:

- [x] source verification JSON with `basic_auth` and others
- [x] source verification with other providers
- [x] destination verification JSON
- [x] connection filter & transform rules