### PR TITLE
fix: Make source verification JSON sensitive

### DIFF
--- a/docs/resources/source_verification.md
+++ b/docs/resources/source_verification.md
@@ -53,7 +53,7 @@ Optional:
 - `github` (Attributes) (see [below for nested schema](#nestedatt--verification--github))
 - `gitlab` (Attributes) (see [below for nested schema](#nestedatt--verification--gitlab))
 - `hmac` (Attributes) (see [below for nested schema](#nestedatt--verification--hmac))
-- `json` (String)
+- `json` (String, Sensitive)
 - `linear` (Attributes) (see [below for nested schema](#nestedatt--verification--linear))
 - `mailgun` (Attributes) (see [below for nested schema](#nestedatt--verification--mailgun))
 - `nmi` (Attributes) (see [below for nested schema](#nestedatt--verification--nmi))

--- a/internal/provider/sourceverification/verification_json.go
+++ b/internal/provider/sourceverification/verification_json.go
@@ -10,7 +10,8 @@ import (
 
 func jsonConfigSchema() schema.StringAttribute {
 	return schema.StringAttribute{
-		Optional: true,
+		Optional:  true,
+		Sensitive: true,
 	}
 }
 


### PR DESCRIPTION
resolves #64 

Great catch! Destination auth JSON is already sensitive. This PR makes source verification JSON sensitive as well.