### PR TITLE
fix: Use set instead of list for connection rules

### DIFF
--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -71,7 +71,7 @@ resource "hookdeck_connection" "connection_example" {
 - `description` (String) Description for the connection
 - `disabled_at` (String) Date the connection was disabled
 - `name` (String) A unique, human-friendly name for the connection
-- `rules` (Attributes List) (see [below for nested schema](#nestedatt--rules))
+- `rules` (Attributes Set) (see [below for nested schema](#nestedatt--rules))
 
 ### Read-Only
 

--- a/internal/provider/connection/schema.go
+++ b/internal/provider/connection/schema.go
@@ -93,7 +93,7 @@ func (r *connectionResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				},
 				Description: "Date the connection was paused",
 			},
-			"rules": schema.ListNestedAttribute{
+			"rules": schema.SetNestedAttribute{
 				Optional: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{


### PR DESCRIPTION
Since Hookdeck connection doesn't alter behavior based on order of individual rule in the rules array, we should use Set instead of List.