### PR TITLE
feat: add region and service to AWS destination auth

### DIFF
--- a/docs/data-sources/destination.md
+++ b/docs/data-sources/destination.md
@@ -73,7 +73,9 @@ Whether the API key should be sent as a header or a query parameter
 Read-Only:
 
 - `access_key_id` (String, Sensitive) AWS access key id
+- `region` (String) AWS region
 - `secret_access_key` (String, Sensitive) AWS secret access key
+- `service` (String) AWS service
 
 
 <a id="nestedatt--auth_method--basic_auth"></a>

--- a/docs/resources/destination.md
+++ b/docs/resources/destination.md
@@ -94,6 +94,11 @@ Required:
 - `access_key_id` (String, Sensitive) AWS access key id
 - `secret_access_key` (String, Sensitive) AWS secret access key
 
+Optional:
+
+- `region` (String) AWS region
+- `service` (String) AWS service
+
 
 <a id="nestedatt--auth_method--basic_auth"></a>
 ### Nested Schema for `auth_method.basic_auth`

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -9,7 +9,7 @@ variable "HEADER_FILTER_VALUES" {
 terraform {
   required_providers {
     hookdeck = {
-      source = "hookdeck/hookdeck"
+      source  = "hookdeck/hookdeck"
       version = "0.5.0-beta.1"
     }
   }
@@ -71,10 +71,10 @@ resource "hookdeck_destination" "aws_destination" {
   url  = "https://mock.hookdeck.com"
   auth_method = {
     aws_signature = {
-      access_key_id = "some-access"
+      access_key_id     = "some-access"
       secret_access_key = "some-secret"
-      region = "us-west-2"
-      service = "lambda"
+      region            = "us-west-2"
+      service           = "lambda"
     }
   }
 }

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -10,6 +10,7 @@ terraform {
   required_providers {
     hookdeck = {
       source = "hookdeck/hookdeck"
+      version = "0.5.0-beta.1"
     }
   }
 }
@@ -61,6 +62,19 @@ resource "hookdeck_destination" "second_destination" {
     basic_auth = {
       username = "some-username"
       password = "blah-blah-blah"
+    }
+  }
+}
+
+resource "hookdeck_destination" "aws_destination" {
+  name = "aws_destination"
+  url  = "https://mock.hookdeck.com"
+  auth_method = {
+    aws_signature = {
+      access_key_id = "some-access"
+      secret_access_key = "some-secret"
+      region = "us-west-2"
+      service = "lambda"
     }
   }
 }

--- a/internal/codegen/codegen.go
+++ b/internal/codegen/codegen.go
@@ -10,7 +10,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-const hookdeckOpenAPISchemaURI = "https://api.hookdeck.com/latest/openapi"
+const hookdeckOpenAPISchemaURI = "https://raw.githubusercontent.com/hookdeck/hookdeck-api-schema/refs/heads/main/openapi.json"
 
 func RunCodeGen() error {
 	fmt.Println("generating Hookdeck source verifications")

--- a/internal/provider/destination/authentication_awssignature.go
+++ b/internal/provider/destination/authentication_awssignature.go
@@ -10,6 +10,8 @@ import (
 type awsSignatureAuthenticationMethodModel struct {
 	AccessKeyID     types.String `tfsdk:"access_key_id"`
 	SecretAccessKey types.String `tfsdk:"secret_access_key"`
+	Region          types.String `tfsdk:"region"`
+	Service         types.String `tfsdk:"service"`
 }
 
 type awsSignatureAuthenticationMethod struct {
@@ -33,6 +35,16 @@ func (*awsSignatureAuthenticationMethod) schema() schema.Attribute {
 				Sensitive:   true,
 				Description: `AWS secret access key`,
 			},
+			"region": schema.StringAttribute{
+				Optional:    true,
+				Sensitive:   false,
+				Description: `AWS region`,
+			},
+			"service": schema.StringAttribute{
+				Optional:    true,
+				Sensitive:   false,
+				Description: `AWS service`,
+			},
 		},
 		Description: `AWS Signature`,
 	}
@@ -42,6 +54,8 @@ func awsSignatureAuthenticationMethodAttrTypesMap() map[string]attr.Type {
 	return map[string]attr.Type{
 		"access_key_id":     types.StringType,
 		"secret_access_key": types.StringType,
+		"region":            types.StringType,
+		"service":           types.StringType,
 	}
 }
 
@@ -61,6 +75,12 @@ func (awsSignatureAuthenticationMethod) refresh(m *destinationResourceModel, des
 	m.AuthMethod.AWSSignature = &awsSignatureAuthenticationMethodModel{}
 	m.AuthMethod.AWSSignature.AccessKeyID = types.StringValue(destination.AuthMethod.AwsSignature.Config.AccessKeyId)
 	m.AuthMethod.AWSSignature.SecretAccessKey = types.StringValue(destination.AuthMethod.AwsSignature.Config.SecretAccessKey)
+	if destination.AuthMethod.AwsSignature.Config.Region != nil {
+		m.AuthMethod.AWSSignature.Region = types.StringValue(*destination.AuthMethod.AwsSignature.Config.Region)
+	}
+	if destination.AuthMethod.AwsSignature.Config.Service != nil {
+		m.AuthMethod.AWSSignature.Service = types.StringValue(*destination.AuthMethod.AwsSignature.Config.Service)
+	}
 }
 
 func (awsSignatureAuthenticationMethod) toPayload(method *destinationAuthMethodConfig) *hookdeck.DestinationAuthMethodConfig {
@@ -72,6 +92,8 @@ func (awsSignatureAuthenticationMethod) toPayload(method *destinationAuthMethodC
 		Config: &hookdeck.DestinationAuthMethodAwsSignatureConfig{
 			AccessKeyId:     method.AWSSignature.AccessKeyID.ValueString(),
 			SecretAccessKey: method.AWSSignature.SecretAccessKey.ValueString(),
+			Region:          method.AWSSignature.Region.ValueStringPointer(),
+			Service:         method.AWSSignature.Service.ValueStringPointer(),
 		},
 	})
 }


### PR DESCRIPTION
```
Terraform will perform the following actions:

  # hookdeck_destination.aws_destination will be created
  + resource "hookdeck_destination" "aws_destination" {
      + auth_method              = {
          + aws_signature = {
              + access_key_id     = (sensitive value)
              + region            = "us-west-2"
              + secret_access_key = (sensitive value)
              + service           = "lambda"
            }
        }
      + created_at               = (known after apply)
      + disabled_at              = (known after apply)
      + id                       = (known after apply)
      + name                     = "aws_destination"
      + path_forwarding_disabled = (known after apply)
      + team_id                  = (known after apply)
      + updated_at               = (known after apply)
      + url                      = "https://mock.hookdeck.com"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```